### PR TITLE
allPass

### DIFF
--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -99,3 +99,12 @@ FR.prop('notKey')(propTestObj); // $ExpectError
 FR.prop('key', propTestObj); // $ExpectType number
 FR.prop('key'); // $ExpectType <T extends Record<"key", any>>(obj: T) => T["key"]
 FR.prop('key')(propTestObj); // $ExpectType number
+
+// allPass
+const odd = (n: number) => n % 2 !== 0;
+const lt20 = (n: number) => n < 20;
+const gt5 = (n: number) => n > 5;
+
+R.allPass([odd, lt20, gt5], 20); // $ExpectError
+FR.allPass([odd, lt20, gt5], 20); // $ExpectType boolean
+FR.allPass([odd, lt20, gt5]); // $ExpectType Predicate<number>

--- a/perf/allPass.ts
+++ b/perf/allPass.ts
@@ -6,7 +6,7 @@ const suite = new Benchmark.Suite();
 
 /*
 allPass (ramda) x 600,654 ops/sec ±0.66% (87 runs sampled)
-allPass (fp-ts) x 5,263,519 ops/sec ±0.70% (87 runs sampled)
+allPass (fp-ts) x 8,705,716 ops/sec ±1.66% (89 runs sampled)
 */
 
 const odd = (n: number) => n % 2 !== 0;

--- a/perf/allPass.ts
+++ b/perf/allPass.ts
@@ -1,0 +1,31 @@
+import * as Benchmark from 'benchmark';
+import * as R from 'ramda';
+import * as FR from '../src/';
+
+const suite = new Benchmark.Suite();
+
+/*
+allPass (ramda) x 600,654 ops/sec ±0.66% (87 runs sampled)
+allPass (fp-ts) x 5,263,519 ops/sec ±0.70% (87 runs sampled)
+*/
+
+const odd = (n: number) => n % 2 !== 0;
+const lt20 = (n: number) => n < 20;
+const gt5 = (n: number) => n > 5;
+
+suite
+  .add('allPass (ramda)', function() {
+    R.allPass([odd, lt20, gt5])(20);
+  })
+  .add('allPass (fp-ts)', function() {
+    FR.allPass([odd, lt20, gt5])(20);
+  })
+  .on('cycle', function(event: any) {
+    // tslint:disable-next-line: no-console
+    console.log(String(event.target));
+  })
+  .on('complete', function(this: any) {
+    // tslint:disable-next-line: no-console
+    console.log('Fastest is ' + this.filter('fastest').map('name'));
+  })
+  .run({ async: true });

--- a/src/allPass.ts
+++ b/src/allPass.ts
@@ -3,10 +3,12 @@ import { Predicate } from 'fp-ts/lib/function';
 import { monoidAll } from 'fp-ts/lib/Monoid';
 import { pipe } from 'fp-ts/lib/pipeable';
 
+const monoidAllFoldMap = foldMap(monoidAll);
+
 function _allPass<T>(predicates: Array<Predicate<T>>, val: T): boolean {
   return pipe(
     predicates,
-    foldMap(monoidAll)(pred => pred(val))
+    monoidAllFoldMap(predicate => predicate(val))
   );
 }
 

--- a/src/allPass.ts
+++ b/src/allPass.ts
@@ -1,0 +1,24 @@
+import { foldMap } from 'fp-ts/lib/Array';
+import { Predicate } from 'fp-ts/lib/function';
+import { monoidAll } from 'fp-ts/lib/Monoid';
+import { pipe } from 'fp-ts/lib/pipeable';
+
+function _allPass<T>(predicates: Array<Predicate<T>>, val: T): boolean {
+  return pipe(
+    predicates,
+    foldMap(monoidAll)(pred => pred(val))
+  );
+}
+
+/**
+ * Similar to [R.allPass](https://ramdajs.com/docs/#allPass). Returns a curried unary
+ * predicate rather than a function whose arity matches that of the highest-arity predicate supplied.
+ *
+ * @since 0.1.4
+ */
+
+export function allPass<T>(predicates: Array<Predicate<T>>): Predicate<T>;
+export function allPass<T>(predicates: Array<Predicate<T>>, val: T): boolean;
+export function allPass<T>(predicates: Array<Predicate<T>>, val?: T): Predicate<T> | boolean {
+  return val ? _allPass(predicates, val) : val => _allPass(predicates, val);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './allPass';
 export * from './fromPairs';
 export * from './toPairs';
 export * from './xprod';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -173,8 +173,11 @@ describe('fp-ts-ramda', () => {
     const lt20 = (n: number) => n < 20;
     const gt5 = (n: number) => n > 5;
     fc.assert(
-      fc.property(fc.integer(), num =>
-        eqBoolean.equals(R.allPass([odd, lt20, gt5])(num), FR.allPass([odd, lt20, gt5])(num))
+      fc.property(
+        fc.integer(),
+        num =>
+          eqBoolean.equals(R.allPass([odd, lt20, gt5])(num), FR.allPass([odd, lt20, gt5])(num)) &&
+          eqBoolean.equals(R.allPass([])(num), FR.allPass([])(num))
       )
     );
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import * as fc from 'fast-check';
 import { getEq as getArrayEq } from 'fp-ts/lib/Array';
-import { fromEquals, getStructEq, strictEqual } from 'fp-ts/lib/Eq';
+import { eqBoolean, fromEquals, getStructEq, strictEqual } from 'fp-ts/lib/Eq';
 import { Ord, ordDate, ordNumber, ordString } from 'fp-ts/lib/Ord';
 import { getEq as getRecordEq } from 'fp-ts/lib/Record';
 import * as R from 'ramda';
@@ -165,6 +165,16 @@ describe('fp-ts-ramda', () => {
         ({ obj, key }) => {
           return JSONEqual(R.prop(key, obj), FR.prop(key, obj)) && JSONEqual(R.prop(key)(obj), FR.prop(key)(obj));
         }
+      )
+    );
+  });
+  it('allPass', () => {
+    const odd = (n: number) => n % 2 !== 0;
+    const lt20 = (n: number) => n < 20;
+    const gt5 = (n: number) => n > 5;
+    fc.assert(
+      fc.property(fc.integer(), num =>
+        eqBoolean.equals(R.allPass([odd, lt20, gt5])(num), FR.allPass([odd, lt20, gt5])(num))
       )
     );
   });


### PR DESCRIPTION
Here is an initial shot at an `allPass` implementation. There are two changes compared to the ramda version:

1) As you mentioned in the issue, this version of `allPass` does not return a `a curried function whose arity matches that of the highest-arity predicate`, it only returns a curried unary function.

2) The ramda version of `allPass` doesn't allow you to call it in an uncurried manner, you have to always supply the array of predicates and then the value. This version allows either and is non-breaking. I would be fine making it exactly the same if that is what you preferred.

I also added a performance test which shows this implementation is ~9x faster than ramda's version (600,654 vs. 5,263,519 ops/sec on my machine). Just for comparison sake, using the built in `every` method achieved roughly 30 million ops / sec. 