### PR TITLE
allPass currying fix

### DIFF
--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -107,4 +107,5 @@ const gt5 = (n: number) => n > 5;
 
 R.allPass([odd, lt20, gt5], 20); // $ExpectError
 FR.allPass([odd, lt20, gt5], 20); // $ExpectType boolean
+FR.allPass([odd, lt20, gt5], 0); // $ExpectType boolean
 FR.allPass([odd, lt20, gt5]); // $ExpectType Predicate<number>

--- a/src/allPass.ts
+++ b/src/allPass.ts
@@ -22,5 +22,5 @@ function _allPass<T>(predicates: Array<Predicate<T>>, val: T): boolean {
 export function allPass<T>(predicates: Array<Predicate<T>>): Predicate<T>;
 export function allPass<T>(predicates: Array<Predicate<T>>, val: T): boolean;
 export function allPass<T>(predicates: Array<Predicate<T>>, val?: T): Predicate<T> | boolean {
-  return val ? _allPass(predicates, val) : val => _allPass(predicates, val);
+  return val === undefined ? val => _allPass(predicates, val) : _allPass(predicates, val);
 }


### PR DESCRIPTION
I realized in my implementation that the currying would behave unexpectedly if a falsy value was supplied, so I made the condition in the ternary expression explicitly check for the argument to be undefined. 