### PR TITLE
equals

### DIFF
--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -121,3 +121,11 @@ FR.any(odd); // $ExpectType Predicate<number[]>
 // all
 FR.all(odd, [20]); // $ExpectType boolean
 FR.all(odd); // $ExpectType Predicate<number[]>
+
+// equals
+FR.equals(eqNumber); // { <B extends number, C extends number>(x: B, y: C): boolean; <B extends number>(x: B): <C extends number>(y: C) => boolean; }
+FR.equals(eqNumber, 125); // <C extends number>(y: C) => boolean
+FR.equals(eqNumber)(125); // <C extends number>(y: C) => boolean
+FR.equals(eqNumber)(123)(39); // $ExpectType boolean
+FR.equals(eqNumber, 36, 136); // $ExpectType boolean
+FR.equals(eqNumber, '', 0); // $ExpectError

--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -123,9 +123,9 @@ FR.all(odd, [20]); // $ExpectType boolean
 FR.all(odd); // $ExpectType Predicate<number[]>
 
 // equals
-FR.equals(eqNumber); // { <B extends number, C extends number>(x: B, y: C): boolean; <B extends number>(x: B): <C extends number>(y: C) => boolean; }
-FR.equals(eqNumber, 125); // <C extends number>(y: C) => boolean
-FR.equals(eqNumber)(125); // <C extends number>(y: C) => boolean
+FR.equals(eqNumber); // $ExpectType { <B extends number, C extends number>(x: B, y: C): boolean; <B extends number>(x: B): <C extends number>(y: C) => boolean; }
+FR.equals(eqNumber, 125); // $ExpectType <C extends number>(y: C) => boolean
+FR.equals(eqNumber)(125); // $ExpectType <C extends number>(y: C) => boolean
 FR.equals(eqNumber)(123)(39); // $ExpectType boolean
 FR.equals(eqNumber, 36, 136); // $ExpectType boolean
 FR.equals(eqNumber, '', 0); // $ExpectError

--- a/dtslint/ts3.5/index.ts
+++ b/dtslint/ts3.5/index.ts
@@ -123,9 +123,8 @@ FR.all(odd, [20]); // $ExpectType boolean
 FR.all(odd); // $ExpectType Predicate<number[]>
 
 // equals
-FR.equals(eqNumber); // $ExpectType { <B extends number, C extends number>(x: B, y: C): boolean; <B extends number>(x: B): <C extends number>(y: C) => boolean; }
-FR.equals(eqNumber, 125); // $ExpectType <C extends number>(y: C) => boolean
-FR.equals(eqNumber)(125); // $ExpectType <C extends number>(y: C) => boolean
+FR.equals(eqNumber); // $ExpectType { (x: number, y: number): boolean; (x: number): Predicate<number>; }
+FR.equals(eqNumber)(125); // $ExpectType Predicate<number>
 FR.equals(eqNumber)(123)(39); // $ExpectType boolean
-FR.equals(eqNumber, 36, 136); // $ExpectType boolean
-FR.equals(eqNumber, '', 0); // $ExpectError
+FR.equals(eqNumber)(36, 136); // $ExpectType boolean
+FR.equals(eqNumber)('', 0); // $ExpectError

--- a/perf/equals.ts
+++ b/perf/equals.ts
@@ -6,10 +6,10 @@ import * as FR from '../src/';
 const suite = new Benchmark.Suite();
 
 /*
-equals (ramda) x 2,552,747 ops/sec ±0.59% (85 runs sampled)
-equals (ramda - curried) x 1,659,114 ops/sec ±0.65% (86 runs sampled)
-equals (fp-ts) x 104,351,654 ops/sec ±0.55% (88 runs sampled)
-equals (fp-ts - curried) x 24,471,223 ops/sec ±0.77% (87 runs sampled)
+equals (ramda) x 2,698,018 ops/sec ±0.78% (92 runs sampled)
+equals (ramda - curried) x 1,639,434 ops/sec ±2.79% (84 runs sampled)
+equals (fp-ts) x 809,243,611 ops/sec ±0.46% (92 runs sampled)
+equals (fp-ts - curried) x 38,973,438 ops/sec ±0.86% (84 runs sampled)
 */
 
 suite
@@ -20,7 +20,7 @@ suite
     R.equals(10)(20);
   })
   .add('equals (fp-ts)', function() {
-    FR.equals(eqNumber, 10, 20);
+    FR.equals(eqNumber)(10, 20);
   })
   .add('equals (fp-ts - curried)', function() {
     FR.equals(eqNumber)(10)(20);

--- a/perf/equals.ts
+++ b/perf/equals.ts
@@ -1,0 +1,36 @@
+import * as Benchmark from 'benchmark';
+import { eqNumber } from 'fp-ts/lib/Eq';
+import * as R from 'ramda';
+import * as FR from '../src/';
+
+const suite = new Benchmark.Suite();
+
+/*
+equals (ramda) x 2,552,747 ops/sec ±0.59% (85 runs sampled)
+equals (ramda - curried) x 1,659,114 ops/sec ±0.65% (86 runs sampled)
+equals (fp-ts) x 104,351,654 ops/sec ±0.55% (88 runs sampled)
+equals (fp-ts - curried) x 24,471,223 ops/sec ±0.77% (87 runs sampled)
+*/
+
+suite
+  .add('equals (ramda)', function() {
+    R.equals(10, 20);
+  })
+  .add('equals (ramda - curried)', function() {
+    R.equals(10)(20);
+  })
+  .add('equals (fp-ts)', function() {
+    FR.equals(eqNumber, 10, 20);
+  })
+  .add('equals (fp-ts - curried)', function() {
+    FR.equals(eqNumber)(10)(20);
+  })
+  .on('cycle', function(event: any) {
+    // tslint:disable-next-line: no-console
+    console.log(String(event.target));
+  })
+  .on('complete', function(this: any) {
+    // tslint:disable-next-line: no-console
+    console.log('Fastest is ' + this.filter('fastest').map('name'));
+  })
+  .run({ async: true });

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -1,0 +1,34 @@
+import { Eq } from 'fp-ts/lib/Eq';
+
+/**
+ * Similar to [R.equals](https://ramdajs.com/docs/#equals), but:
+ * - Requires an explicit `Eq<A>` instance
+ * - Does not directly handle cyclical data structures, relies on `Eq<A> instance to determine equality
+ * - Does not dispatch to the `equals` method of both arguments if present
+ *
+ * @since 0.1.7
+ */
+
+export function equals<A>(
+  E: Eq<A>
+): {
+  <B extends A, C extends A>(x: B, y: C): boolean;
+  <B extends A>(x: B): <C extends A>(y: C) => boolean;
+};
+export function equals<A, B extends A>(E: Eq<A>, x: B): <C extends A>(y: C) => boolean;
+export function equals<A, B extends A, C extends A>(E: Eq<A>, x: B, y: C): boolean;
+export function equals<A, B extends A, C extends A>(E: Eq<A>, x?: B, y?: C): any {
+  if (x === undefined) {
+    return <B extends A, C extends A>(x: B, y?: C) => {
+      if (y === undefined) {
+        return <C extends A>(y: C) => E.equals(x, y);
+      } else {
+        return E.equals(x, y);
+      }
+    };
+  } else if (y === undefined) {
+    return <C extends A>(y: C) => E.equals(x, y);
+  } else {
+    return E.equals(x, y);
+  }
+}

--- a/src/equals.ts
+++ b/src/equals.ts
@@ -1,4 +1,5 @@
 import { Eq } from 'fp-ts/lib/Eq';
+import { Predicate } from 'fp-ts/lib/function';
 
 /**
  * Similar to [R.equals](https://ramdajs.com/docs/#equals), but:
@@ -12,23 +13,15 @@ import { Eq } from 'fp-ts/lib/Eq';
 export function equals<A>(
   E: Eq<A>
 ): {
-  <B extends A, C extends A>(x: B, y: C): boolean;
-  <B extends A>(x: B): <C extends A>(y: C) => boolean;
+  (x: A, y: A): boolean;
+  (x: A): Predicate<A>;
 };
-export function equals<A, B extends A>(E: Eq<A>, x: B): <C extends A>(y: C) => boolean;
-export function equals<A, B extends A, C extends A>(E: Eq<A>, x: B, y: C): boolean;
-export function equals<A, B extends A, C extends A>(E: Eq<A>, x?: B, y?: C): any {
-  if (x === undefined) {
-    return <B extends A, C extends A>(x: B, y?: C) => {
-      if (y === undefined) {
-        return <C extends A>(y: C) => E.equals(x, y);
-      } else {
-        return E.equals(x, y);
-      }
-    };
-  } else if (y === undefined) {
-    return <C extends A>(y: C) => E.equals(x, y);
-  } else {
-    return E.equals(x, y);
-  }
+export function equals<A>(E: Eq<A>): (x: A, y?: A) => Predicate<A> | boolean {
+  return (x, y) => {
+    if (y === undefined) {
+      return y => E.equals(x, y);
+    } else {
+      return E.equals(x, y);
+    }
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export * from './prop';
 export * from './anyPass';
 export * from './any';
 export * from './all';
+export * from './equals';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import * as fc from 'fast-check';
-import { getEq as getArrayEq } from 'fp-ts/lib/Array';
-import { eqBoolean, fromEquals, getStructEq, strictEqual } from 'fp-ts/lib/Eq';
+import { getEq, getEq as getArrayEq } from 'fp-ts/lib/Array';
+import { eqBoolean, eqNumber, eqString, fromEquals, getStructEq, strictEqual } from 'fp-ts/lib/Eq';
 import { flow } from 'fp-ts/lib/function';
 import { Ord, ordDate, ordNumber, ordString } from 'fp-ts/lib/Ord';
 import { getEq as getRecordEq } from 'fp-ts/lib/Record';
@@ -276,6 +276,52 @@ describe('fp-ts-ramda', () => {
           )
       ),
       { examples: [[[]]] }
+    );
+  });
+  it('equals', () => {
+    fc.assert(
+      fc.property(
+        fc.integer(),
+        fc.integer(),
+        (x, y) =>
+          eqBoolean.equals(R.equals(x, y), FR.equals(eqNumber, x, y)) &&
+          eqBoolean.equals(R.equals(x)(y), FR.equals(eqNumber)(x)(y))
+      ),
+      {
+        examples: [[0, 0]]
+      }
+    );
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.string(),
+        (x, y) =>
+          eqBoolean.equals(R.equals(x, y), FR.equals(eqString, x, y)) &&
+          eqBoolean.equals(R.equals(x)(y), FR.equals(eqString)(x)(y))
+      ),
+      {
+        examples: [['', '']]
+      }
+    );
+    fc.assert(
+      fc.property(
+        fc.boolean(),
+        fc.boolean(),
+        (x, y) =>
+          eqBoolean.equals(R.equals(x, y), FR.equals(eqBoolean, x, y)) &&
+          eqBoolean.equals(R.equals(x)(y), FR.equals(eqBoolean)(x)(y))
+      )
+    );
+    fc.assert(
+      fc.property(
+        fc.array(fc.string()),
+        as =>
+          eqBoolean.equals(R.equals(as, as), FR.equals(getEq(eqString), as, as)) &&
+          eqBoolean.equals(R.equals(as)(as), FR.equals(getEq(eqString))(as)(as))
+      ),
+      {
+        examples: [[[]]]
+      }
     );
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -284,7 +284,7 @@ describe('fp-ts-ramda', () => {
         fc.integer(),
         fc.integer(),
         (x, y) =>
-          eqBoolean.equals(R.equals(x, y), FR.equals(eqNumber, x, y)) &&
+          eqBoolean.equals(R.equals(x, y), FR.equals(eqNumber)(x, y)) &&
           eqBoolean.equals(R.equals(x)(y), FR.equals(eqNumber)(x)(y))
       ),
       {
@@ -296,7 +296,7 @@ describe('fp-ts-ramda', () => {
         fc.string(),
         fc.string(),
         (x, y) =>
-          eqBoolean.equals(R.equals(x, y), FR.equals(eqString, x, y)) &&
+          eqBoolean.equals(R.equals(x, y), FR.equals(eqString)(x, y)) &&
           eqBoolean.equals(R.equals(x)(y), FR.equals(eqString)(x)(y))
       ),
       {
@@ -308,7 +308,7 @@ describe('fp-ts-ramda', () => {
         fc.boolean(),
         fc.boolean(),
         (x, y) =>
-          eqBoolean.equals(R.equals(x, y), FR.equals(eqBoolean, x, y)) &&
+          eqBoolean.equals(R.equals(x, y), FR.equals(eqBoolean)(x, y)) &&
           eqBoolean.equals(R.equals(x)(y), FR.equals(eqBoolean)(x)(y))
       )
     );
@@ -316,7 +316,7 @@ describe('fp-ts-ramda', () => {
       fc.property(
         fc.array(fc.string()),
         as =>
-          eqBoolean.equals(R.equals(as, as), FR.equals(getEq(eqString), as, as)) &&
+          eqBoolean.equals(R.equals(as, as), FR.equals(getEq(eqString))(as, as)) &&
           eqBoolean.equals(R.equals(as)(as), FR.equals(getEq(eqString))(as)(as))
       ),
       {


### PR DESCRIPTION
Here is an attempt at equals. The type signature seems unnecessarily complicated but it was a result of typescript interpreting certain values as type literals which caused issues with type inference in currying.

For instance, when I only had one type parameter `A` for everything. 

`FR.equals(eqNumber, 125)` returned an expected type of `Predicate<125>` rather than `Predicate<number>`.  Obviously you could fix this by calling `FR.equals<number>(eqNumber, 125)` but that seemed to be poor ergonomics for the developer.

I'm open to any suggestions you have on this. 